### PR TITLE
Split vesting schedule, added sealing, variable initial token amounts

### DIFF
--- a/contracts/Token.sol
+++ b/contracts/Token.sol
@@ -11,14 +11,6 @@ import "./IVestingToken.sol";
 contract Token is Initializable, OwnableUpgradeable, ERC20Upgradeable, UUPSUpgradeable, IVestingToken {
     using SafeMath for uint;
 
-    address public constant _existingHolders = 0x0364eAA7C884cb5495013804275120ab023619A5;
-    address public constant _outlierVentures = 0x0364eAA7C884cb5495013804275120ab023619A5;
-    address public constant _investors = 0x0364eAA7C884cb5495013804275120ab023619A5;
-    address public constant _foundation = 0xB1C0a6ea0c0E54c4150ffA3e984b057d25d8b28C;
-    address public constant _growth = 0x0364eAA7C884cb5495013804275120ab023619A5;
-    address public constant _advisors = 0x0364eAA7C884cb5495013804275120ab023619A5;
-    address public constant _curve = 0x0364eAA7C884cb5495013804275120ab023619A5;
-
     uint256 public holderCount;
     address public vestingContract;
 
@@ -26,17 +18,16 @@ contract Token is Initializable, OwnableUpgradeable, ERC20Upgradeable, UUPSUpgra
      * @dev Our constructor (with UUPS upgrades we need to use initialize(), but this is only
      *      able to be called once because of the initializer modifier.
      */
-    function initialize() public initializer {
+    function initialize(address[] memory recipients, uint256[] memory amounts) public initializer {
+        require(recipients.length == amounts.length, "Token: recipients and amounts must match");
+
         __Ownable_init();
         __ERC20_init("moda", "MODA");
 
-        _mintWithCount(_existingHolders, 2000000 * 10 ** 18);
-        _mintWithCount(_outlierVentures, 300000 * 10 ** 18);
-        _mintWithCount(_investors, 500000 * 10 ** 18);
-        _mintWithCount(_foundation, 3500000 * 10 ** 18);
-        _mintWithCount(_growth, 1000000 * 10 ** 18);
-        _mintWithCount(_advisors, 1200000 * 10 ** 18);
-        _mintWithCount(_curve, 1500000 * 10 ** 18);
+        uint256 length = recipients.length;
+        for (uint i = 0; i < length; i++) {
+            _mintWithCount(recipients[i], amounts[i]);
+        }
     }
 
     /**

--- a/contracts/Vesting.sol
+++ b/contracts/Vesting.sol
@@ -36,7 +36,7 @@ contract Vesting is Ownable {
         emit ScheduleChanged(to, schedule[to]);
     }
 
-    event ScheduleChanged(address to, VestingSchedule[] newSchedule);
+    event ScheduleChanged(address indexed to, VestingSchedule[] newSchedule);
 
     function seal() external onlyOwner {
         vestingSealed = true;

--- a/contracts/Vesting.sol
+++ b/contracts/Vesting.sol
@@ -1,39 +1,60 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "./IVestingToken.sol";
 
 struct VestingSchedule {
-    address to;
     uint256 amount;
     uint256 releaseDate;
     bool released;
 }
 
-contract Vesting {
+contract Vesting is Ownable {
     using SafeMath for uint256;
 
-    IVestingToken immutable private _token; // Token
-    VestingSchedule[] private _schedule; // Vesting Schedule
-    
-    constructor(address token, VestingSchedule[] memory schedule) {
-        require(token != address(0), "Vesting: invalid token address");
-        require(schedule.length > 0, "Vesting: invalid schedule");
+    IVestingToken immutable public token;
+    mapping(address => VestingSchedule[]) public schedule;
+    bool public vestingSealed;
 
-        _token = IVestingToken(token);
+    constructor(address tokenContract) {
+        require(tokenContract != address(0), "Vesting: invalid token address");
 
-        for (uint i = 0; i < schedule.length; i++) {
-            _schedule.push(schedule[i]);
-        }
+        token = IVestingToken(tokenContract);
     }
 
+    function addToSchedule(address to, VestingSchedule[] memory newEntries) external onlyOwner {
+        require(vestingSealed == false, "Vesting: sealed");
+        require(to != address(0), "Vesting: to address must not be 0");
+        require(newEntries.length > 0, "Vesting: no entries");
+
+        for (uint i = 0; i < newEntries.length; i++) {
+            schedule[to].push(newEntries[i]);
+        }
+        
+        emit ScheduleChanged(to, schedule[to]);
+    }
+
+    event ScheduleChanged(address to, VestingSchedule[] newSchedule);
+
+    function seal() external onlyOwner {
+        vestingSealed = true;
+        emit VestingSealed();
+    }
+
+    event VestingSealed();
+
     function withdrawalAmount(address to) public view returns (uint256) {
+        if (!vestingSealed) return 0;
+
         uint256 total; // Note: Not explicitly initialising to zero to save gas, default value of uint256 is 0.
 
-        for (uint i = 0; i < _schedule.length; i++) {
-            if (_schedule[i].to == to && _schedule[i].releaseDate <= block.timestamp && _schedule[i].released == false) {
-                total = total.add(_schedule[i].amount);
+        VestingSchedule[] memory entries = schedule[to];
+        for (uint i = 0; i < entries.length; i++) {
+            VestingSchedule memory entry = entries[i];
+            if (entry.releaseDate <= block.timestamp && entry.released == false) {
+                total = total.add(entry.amount);
             }
         }
 
@@ -41,20 +62,24 @@ contract Vesting {
     }
 
     function withdraw() public {
+        require(vestingSealed, "Vesting: not sealed");
+
         uint256 total; // Note: Not explicitly initialising to zero to save gas, default value of uint256 is 0.
 
         // We're not using the withdrawalAmount function here because we need to mark them as withdrawn as we
         // iterate the loop to avoid a second iteration.
-        for (uint i = 0; i < _schedule.length; i++) {
-            if (_schedule[i].to == msg.sender && _schedule[i].releaseDate <= block.timestamp && _schedule[i].released == false) {
-                _schedule[i].released = true;
-                total = total.add(_schedule[i].amount);
+        VestingSchedule[] memory entries = schedule[msg.sender];
+        for (uint i = 0; i < entries.length; i++) {
+            VestingSchedule memory entry = entries[i];
+            if (entry.releaseDate <= block.timestamp && entry.released == false) {
+                schedule[msg.sender][i].released = true;
+                total = total.add(entry.amount);
             }
         }
 
         require(total > 0, "Vesting: no amount to withdraw");
 
-        _token.vestingMint(msg.sender, total);
+        token.vestingMint(msg.sender, total);
 
         emit Vested(msg.sender, total);
     }

--- a/test/vesting.test.ts
+++ b/test/vesting.test.ts
@@ -20,7 +20,17 @@ describe('Vesting', () => {
 		start = fromTimestamp(currentBlock.timestamp);
 
 		const TokenFactory = await ethers.getContractFactory('Token');
-		token = (await upgrades.deployProxy(TokenFactory, { kind: 'uups' })) as Token;
+		token = (await upgrades.deployProxy(
+			TokenFactory,
+			[
+				[
+					'0x0364eAA7C884cb5495013804275120ab023619A5',
+					'0xB1C0a6ea0c0E54c4150ffA3e984b057d25d8b28C',
+				],
+				[ethers.utils.parseEther('6500000'), ethers.utils.parseEther('3500000')],
+			],
+			{ kind: 'uups' }
+		)) as Token;
 		await token.deployed();
 
 		const VestingFactory = await ethers.getContractFactory('Vesting');


### PR DESCRIPTION
**Vesting Schedule**
The previous vesting schedule was capped in size because it was all in one array. Given how many we're likely to have, this PR splits the amounts into a mapping and allows multiple separate calls to initialise the full schedule.

As such, there needs to be a way to indicate we're done with that. I've added sealing, and once sealed the contract cannot be unsealed, even by the owner.

**Token**
Pulled initial amounts out into the initialize function so we can choose them later.